### PR TITLE
chore: retry if turnstile not available

### DIFF
--- a/priv/static/phoenix_turnstile.js
+++ b/priv/static/phoenix_turnstile.js
@@ -46,7 +46,7 @@ export const TurnstileHook = {
 
     if (typeof turnstile === "undefined") {
       intervalId = setInterval(() => {
-        if (turnstile) {
+        if (typeof turnstile !== "undefined") {
           setupTurnstile.call(this)
           clearInterval(intervalId)
         }

--- a/priv/static/phoenix_turnstile.js
+++ b/priv/static/phoenix_turnstile.js
@@ -40,6 +40,8 @@ function setupTurnstile() {
   })
 }
 
+const intervalTime = 250
+
 export const TurnstileHook = {
   mounted() {
     let intervalId
@@ -50,7 +52,7 @@ export const TurnstileHook = {
           setupTurnstile.call(this)
           clearInterval(intervalId)
         }
-      }, 250)
+      }, intervalTime)
     } else {
       setupTurnstile.call(this)
     }

--- a/priv/static/phoenix_turnstile.js
+++ b/priv/static/phoenix_turnstile.js
@@ -8,28 +8,51 @@ function callbackEvent(self, name, eventName) {
   }
 }
 
+function setupTurnstile() {
+  turnstile.render(this.el, {
+    callback: callbackEvent(this, "success"),
+    "error-callback": callbackEvent(this, "error"),
+    "expired-callback": callbackEvent(this, "expired"),
+    "before-interactive-callback": callbackEvent(
+      this,
+      "beforeInteractive",
+      "before-interactive"
+    ),
+    "after-interactive-callback": callbackEvent(
+      this,
+      "afterInteractive",
+      "after-interactive"
+    ),
+    "unsupported-callback": callbackEvent(this, "unsupported"),
+    "timeout-callback": callbackEvent(this, "timeout"),
+  })
+
+  this.handleEvent("turnstile:refresh", (event) => {
+    if (!event.id || event.id === this.el.id) {
+      turnstile.reset(this.el)
+    }
+  })
+
+  this.handleEvent("turnstile:remove", (event) => {
+    if (!event.id || event.id === this.el.id) {
+      turnstile.remove(this.el)
+    }
+  })
+}
+
 export const TurnstileHook = {
   mounted() {
-    turnstile.render(this.el, {
-      callback: callbackEvent(this, "success"),
-      "error-callback": callbackEvent(this, "error"),
-      "expired-callback": callbackEvent(this, "expired"),
-      "before-interactive-callback": callbackEvent(this, "beforeInteractive", "before-interactive"),
-      "after-interactive-callback": callbackEvent(this, "afterInteractive", "after-interactive"),
-      "unsupported-callback": callbackEvent(this, "unsupported"),
-      "timeout-callback": callbackEvent(this, "timeout")
-    })
+    let intervalId
 
-    this.handleEvent("turnstile:refresh", (event) => {
-      if (!event.id || event.id === this.el.id) {
-        turnstile.reset(this.el)
-      }
-    })
-
-    this.handleEvent("turnstile:remove", (event) => {
-      if (!event.id || event.id === this.el.id) {
-        turnstile.remove(this.el)
-      }
-    })
-  }
+    if (typeof turnstile === "undefined") {
+      intervalId = setInterval(() => {
+        if (turnstile) {
+          setupTurnstile.call(this)
+          clearInterval(intervalId)
+        }
+      }, 250)
+    } else {
+      setupTurnstile.call(this)
+    }
+  },
 }

--- a/priv/static/phoenix_turnstile.js
+++ b/priv/static/phoenix_turnstile.js
@@ -3,7 +3,12 @@ function callbackEvent(self, name, eventName) {
     const events = self.el.dataset.events || ""
 
     if (events.split(",").indexOf(name) > -1) {
-      self.pushEventTo(self.el, `turnstile:${eventName || name}`, payload)
+      const eName = `turnstile:${eventName || name}`
+      dispatchEvent(new Event(eName))
+
+      if (typeof liveSocket !== "undefined" && liveSocket.isConnected()) {
+        self.pushEventTo(self.el, eName, payload)
+      }
     }
   }
 }


### PR DESCRIPTION
Make sure `turnstile` is defined before using it.

There are some cases where the hook code can run before turnstile is loaded (we saw this in production code).