### PR TITLE
Added Version number to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
 {
-  "main": "priv/static/phoenix_turnstile.js"
+  "main": "priv/static/phoenix_turnstile.js",
+  "version": "1.1.3"
 }


### PR DESCRIPTION
Yarn fails if the `package.json` does not include a version number.