### PR TITLE
Add support for idempotency_key

### DIFF
--- a/lib/turnstile/behaviour.ex
+++ b/lib/turnstile/behaviour.ex
@@ -8,6 +8,7 @@ defmodule Turnstile.Behaviour do
   @callback remove(map()) :: map()
   @callback remove(map(), binary()) :: map()
 
+  @callback verify(%{binary() => binary()}, keyword()) :: {:ok, term()} | {:error, term()}
   @callback verify(%{binary() => binary()}) :: {:ok, term()} | {:error, term()}
   @callback verify(%{binary() => binary()}, tuple() | binary()) :: {:ok, term()} | {:error, term()}
 end

--- a/test/turnstile_test.exs
+++ b/test/turnstile_test.exs
@@ -74,7 +74,7 @@ defmodule TurnstileTest do
 
   describe "verify/2" do
     test "should return successful status" do
-      use_cassette "turnstile_success", custom: true do
+      use_cassette("turnstile_success", custom: true) do
         assert Turnstile.verify(%{"cf-turnstile-response" => "foo"}) == {:ok, %{"success" => true}}
       end
     end
@@ -87,13 +87,29 @@ defmodule TurnstileTest do
 
     test "should return successful status with charlist ip" do
       use_cassette "turnstile_success", custom: true do
-        assert Turnstile.verify(%{"cf-turnstile-response" => "foo"}, '127.0.0.1') == {:ok, %{"success" => true}}
+        assert Turnstile.verify(%{"cf-turnstile-response" => "foo"}, ~c"127.0.0.1") == {:ok, %{"success" => true}}
       end
     end
 
     test "should return successful status with tuple ip" do
       use_cassette "turnstile_success", custom: true do
         assert Turnstile.verify(%{"cf-turnstile-response" => "foo"}, {127, 0, 0, 1}) == {:ok, %{"success" => true}}
+      end
+    end
+
+    test "should return successful status with keyword options" do
+      use_cassette "turnstile_success", custom: true do
+        assert Turnstile.verify(%{"cf-turnstile-response" => "foo"}, remote_ip: {127, 0, 0, 1}) ==
+                 {:ok, %{"success" => true}}
+      end
+    end
+
+    test "should return successful status with idempotency_key" do
+      use_cassette "turnstile_success", custom: true do
+        assert Turnstile.verify(%{"cf-turnstile-response" => "foo"},
+                 remote_ip: {127, 0, 0, 1},
+                 idempotency_key: "54a814b1-5aed-4f5b-9b41-349ff415a73d"
+               ) == {:ok, %{"success" => true}}
       end
     end
 


### PR DESCRIPTION
This adds support for idempotency_key option for Turnstile.

I've also added a new interface for `verify/2` that takes a keyword list of options to future proof it. 

Suggestion: I think we could improve the testing my adding a separate HTTP client module that can be mocked out using Hammox or Efx to test request payloads & response handling.