### PR TITLE
Make `secret_key` customizable per request

### DIFF
--- a/lib/turnstile/behaviour.ex
+++ b/lib/turnstile/behaviour.ex
@@ -9,5 +9,5 @@ defmodule Turnstile.Behaviour do
   @callback remove(map(), binary()) :: map()
 
   @callback verify(%{binary() => binary()}) :: {:ok, term()} | {:error, term()}
-  @callback verify(%{binary() => binary()}, tuple() | binary()) :: {:ok, term()} | {:error, term()}
+  @callback verify(%{binary() => binary()}, keyword() | tuple() | binary()) :: {:ok, term()} | {:error, term()}
 end

--- a/test/turnstile_test.exs
+++ b/test/turnstile_test.exs
@@ -109,6 +109,29 @@ defmodule TurnstileTest do
       end
     end
 
+    test "should return successful status with secret_key option" do
+      use_cassette "turnstile_success", custom: true do
+        assert Turnstile.verify(%{"cf-turnstile-response" => "foo"}, secret_key: "some_secret_key") ==
+                 {:ok, %{"success" => true}}
+      end
+    end
+
+    test "should return successful status with secret_key and remoteip options" do
+      use_cassette "turnstile_success", custom: true do
+        assert Turnstile.verify(%{"cf-turnstile-response" => "foo"},
+                 secret_key: "some_secret_key",
+                 remoteip: {127, 0, 0, 1}
+               ) == {:ok, %{"success" => true}}
+      end
+    end
+
+    test "should return unsuccessful status with secret_key option" do
+      use_cassette "turnstile_failure", custom: true do
+        assert Turnstile.verify(%{"cf-turnstile-response" => "foo"}, secret_key: "some_secret_key") ==
+                 {:error, %{"success" => false}}
+      end
+    end
+
     @tag :external
     test "should return a successful response" do
       assert {:ok, res} = Turnstile.verify(%{"cf-turnstile-response" => "abc123"})


### PR DESCRIPTION
I needed the option to customize the `secret_key` and `site_key` per request, but the library only allowed a custom `site_key`, so I made the `secret_key` customizable through an option in `Turnstile.verify/2`